### PR TITLE
FIX/PN-13457: add class to avoid page break on multiple recipients bilingual

### DIFF
--- a/templates-assets/styles/index.css
+++ b/templates-assets/styles/index.css
@@ -161,3 +161,7 @@ a.faq-link-perfezionamento {
 .py-16 {
     padding: 21.333px 0;
 }
+
+.page-break-avoid {
+    page-break-inside: avoid;
+}

--- a/templates-assets/templates/NotificationCancelledLegalFact/index.html
+++ b/templates-assets/templates/NotificationCancelledLegalFact/index.html
@@ -47,7 +47,7 @@
 
       <#list notification.recipients as recipient>
         <div class="margin-y-small">
-          <div class="row">
+          <div class="row page-break-avoid">
               <div class="left-col col-5-10">
                 <p><% if (noIta) { %><span><%-denomination%> &bull; </span><% } %><%-it_denomination%></p>
               </div>
@@ -56,7 +56,7 @@
               </div>
           </div>
 
-          <div class="row">
+          <div class="row page-break-avoid">
               <div class="left-col col-5-10">
                 <p><% if (noIta) { %><span><%-fiscalcode%> &bull; </span><% } %><%-it_fiscalcode%></p>
               </div>

--- a/templates-assets/templates/NotificationReceivedLegalFact/index.html
+++ b/templates-assets/templates/NotificationReceivedLegalFact/index.html
@@ -89,7 +89,7 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row page-break-avoid">
           <div class="left-col col-5-10">
             <p><% if (noIta) { %><span><%-fiscalcode%> &bull; </span><% } %><%-it_fiscalcode%></p>
           </div>
@@ -98,7 +98,7 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row page-break-avoid">
           <div class="left-col col-5-10">
             <p><% if (noIta) { %><span><%-digitaldomicile%> &bull; </span><% } %><%-it_digitaldomicile%></p>
           </div>
@@ -115,7 +115,7 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row page-break-avoid">
           <div class="left-col col-5-10">
             <p><% if (noIta) { %><span><%-digitaldomicile_type%> &bull; </span><% } %><%-it_digitaldomicile_type%></p>
           </div>
@@ -133,7 +133,7 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row page-break-avoid">
           <div class="left-col col-5-10">
             <p><% if (noIta) { %><span><%-address%> &bull; </span><% } %><%-it_address%></p>
           </div>

--- a/templates-assets/templates/NotificationReceivedLegalFact/index.html
+++ b/templates-assets/templates/NotificationReceivedLegalFact/index.html
@@ -80,7 +80,7 @@
     <#list notification.recipients as recipient>
       <div class="margin-y-medium">
 
-        <div class="row">
+        <div class="row page-break-avoid">
           <div class="left-col col-5-10">
             <p><% if (noIta) { %><span><%-denomination%> &bull; </span><% } %><%-it_denomination%></p>
           </div>

--- a/templates-assets/templates/PecDeliveryWorkflowLegalFact/index.html
+++ b/templates-assets/templates/PecDeliveryWorkflowLegalFact/index.html
@@ -68,7 +68,7 @@
 
         <#list deliveries as delivery>
             <div class="margin-y-small">
-                <div class="row">
+                <div class="row page-break-avoid">
                     <div class="left-col col-5-10">
                         <p><% if (noIta) { %><span><%-denomination%> &bull; </span><% } %><%-it_denomination%></p>
                     </div>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row page-break-avoid">
                     <div class="left-col col-5-10">
                         <p><% if (noIta) { %><span><%-fiscalcode%> &bull; </span><% } %><%-it_fiscalcode%></p>
                     </div>
@@ -86,7 +86,7 @@
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row page-break-avoid">
                     <div class="left-col col-5-10">
                         <p><% if (noIta) { %><span><%-digitaldomicile%> &bull; </span><% } %><%-it_digitaldomicile%></p>
                     </div>
@@ -105,7 +105,7 @@
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row page-break-avoid">
                     <div class="left-col col-5-10">
                         <p><% if (noIta) { %><span><%-digitaldomicile_type%> &bull; </span><% } %><%-it_digitaldomicile_type%></p>
                     </div>


### PR DESCRIPTION
## Short description
This PR fix page break on template `notification-received-legal-fact` with multiple recipients in slovenian

## List of changes proposed in this pull request
- Add class `page-break-inside: avoid`, managed by OpenHtmlToPdf.

## How to test
Start microservice and call the api `/templates-engine-private/v1/templates/notification-received-legal-fact`

- Header `x-language: SL`
- Body PG 
```{
  "sendDate": "TEST_sendDate",
  "notification": {
    "iun": "TEST_iun",
    "sender": { 
      "paDenomination": "TEST_paDenomination",
      "paTaxId": "TEST_paTaxId"
    },
    "recipients": [
      {
        "denomination": "TEST_denomination",
        "taxId": "TEST_taxId",
        "physicalAddressAndDenomination": null,
        "digitalDomicile": {
          "address": "test@test.it"
        }
      },
      {
        "denomination": "TEST_denomination",
        "taxId": "TEST_taxId",
        "physicalAddressAndDenomination": "TEST_physicalAddressAndDenomination",
        "digitalDomicile": {
          "address": null
        }
      }
    ]
  },
  "subject": "TEST_subject",
  "digests": [
    "TEST_digests",
    "TEST_digests_2"
  ]
}```