### PR TITLE
feat(PN-20537) add sms template for PG

### DIFF
--- a/templates-assets/templates/InformalSMSCommunication/index.txt
+++ b/templates-assets/templates/InformalSMSCommunication/index.txt
@@ -1,1 +1,5 @@
+<#if recipientType == "PF">
 SEND, il servizio di notifiche digitali, ti informa che hai ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi con SPID o CIE al sito di SEND.
+<#elseif recipientType == "PG">
+SEND, il servizio di notifiche digitali, ti informa che la tua impresa ha ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi al sito di SEND.
+</#if>

--- a/templates-assets/templates/InformalSMSCommunication/index.txt
+++ b/templates-assets/templates/InformalSMSCommunication/index.txt
@@ -1,5 +1,5 @@
 <#if recipientType == "PF">
-SEND, il servizio di notifiche digitali, ti informa che hai ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi con SPID o CIE al sito di SEND.
+SEND, il Servizio di Notifiche Digitali, ti informa che hai ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi con SPID o CIE al sito di SEND.
 <#elseif recipientType == "PG">
-SEND, il servizio di notifiche digitali, ti informa che la tua impresa ha ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi al sito di SEND.
+SEND, il Servizio di Notifiche Digitali, informa che la tua impresa ha ricevuto una comunicazione da ${senderPaDenomination}. Per leggerla, accedi al sito di SEND.
 </#if>


### PR DESCRIPTION
## Summary

Differentiate Informal SMS content between PF and PG recipients.

### Changes
- PF recipients continue to receive the existing SMS.
- PG recipients receive the new business-specific SMS message.
- Added FreeMarker conditional logic to the SMS template.