### PR TITLE
feat(PN-20747): remove payment attachment text from IO markdown

### DIFF
--- a/templates-assets/templates/InformalIoCommunication/index.md
+++ b/templates-assets/templates/InformalIoCommunication/index.md
@@ -8,7 +8,7 @@ Per avere maggiori informazioni **prendi visione degli allegati**, che possono f
 </#if>
 <#if hasPayment>
 
-Puoi effettuare il pagamento direttamente sull'app IO premendo **Paga**. In alternativa, puoi utilizzare l'**avviso allegato** per saldare l'importo tramite tutti i canali abilitati a pagoPA.
+Puoi effettuare il pagamento direttamente sull'app IO premendo **Paga**.
 </#if>
 
 In ogni caso, qualora avessi bisogno di assistenza, **contatta ${sender.denomination} attraverso i suoi canali ufficiali**.


### PR DESCRIPTION
## Summary

This PR updates the IO markdown payment section by removing the sentence referring to the attached payment notice, since payment attachments are not part of the MVP.

## Changes

- Removed the sentence:
  > "In alternativa, puoi utilizzare l’avviso allegato per saldare l’importo tramite tutti i canali abilitati a pagoPA."
- Aligned the IO markdown with the MVP requirements.